### PR TITLE
feat: extract native PDF outline via PDF.js reader with heuristic fal…

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -21,6 +21,7 @@ import {
   destroyEmbeddingProviderFactory,
 } from "./modules/embedding";
 import { getStorageDatabase, destroyStorageDatabase } from "./modules/chat/db/StorageDatabase";
+import { destroyPdfToolManager } from "./modules/chat/pdf-tools";
 import { checkAndMigrateToV3 } from "./modules/chat/migration/migrateToSQLite";
 import { destroyMemoryStores } from "./modules/chat/memory/MemoryStore";
 import { destroyMemoryIndexers, getMemoryIndexer } from "./modules/chat/memory/MemoryIndexer";
@@ -164,6 +165,8 @@ async function onShutdown(): Promise<void> {
   destroyMemoryIndexers();
   // Destroy StorageDatabase
   destroyStorageDatabase();
+  // Destroy PdfToolManager (clears in-memory paper structure cache)
+  destroyPdfToolManager();
   await destroyAnalyticsService();
   addon.data.dialog?.window?.close();
   addon.data.alive = false;

--- a/src/modules/chat/pdf-tools/PdfToolManager.ts
+++ b/src/modules/chat/pdf-tools/PdfToolManager.ts
@@ -58,6 +58,7 @@ import { getMemoryService } from "../memory/MemoryService";
 import { executeWebSearch, isValidWebSearchArgs } from "../web-search";
 import { preflightToolArguments } from "../tool-arguments/ToolArgumentPreflight";
 import { parsePaperStructure, parsePages } from "./paperParser";
+import { extractNativeOutline } from "./nativeOutlineExtractor";
 import type { AgentPromptContext } from "./promptGenerator";
 import { generatePaperContextPrompt as generatePaperContextPromptFn } from "./promptGenerator";
 import {
@@ -192,6 +193,28 @@ export class PdfToolManager {
           `[PdfToolManager] Error getting attachments for ${itemKey}:`,
           getErrorMessage(error),
         );
+      }
+    }
+
+    // 如果 PDF 文本解析成功，尝试提取 PDF 原生大纲（增强结构信息）
+    if (structure) {
+      // 优先尝试从打开的 PDF.js reader 获取原生大纲
+      // 仅当缓存中没有 already-resolved nativeOutline 时尝试
+      if (!structure.nativeOutline) {
+        try {
+          const nativeOutline = await extractNativeOutline(itemKey);
+          if (nativeOutline && nativeOutline.length > 0) {
+            structure.nativeOutline = nativeOutline;
+            ztoolkit.log(
+              `[PdfToolManager] Native outline extracted for item: ${itemKey} (${nativeOutline.length} items)`,
+            );
+          }
+        } catch (outlineError) {
+          // 非关键——如果取不到 natives outline，现有 heuristic 结构仍然可用
+          ztoolkit.log(
+            `[PdfToolManager] Native outline extraction skipped (reader may not be open): ${getErrorMessage(outlineError)}`,
+          );
+        }
       }
     }
 

--- a/src/modules/chat/pdf-tools/nativeOutlineExtractor.ts
+++ b/src/modules/chat/pdf-tools/nativeOutlineExtractor.ts
@@ -1,0 +1,158 @@
+/**
+ * Native PDF Outline Extractor
+ *
+ * Extracts the PDF's native outline/bookmarks by accessing the PDF.js viewer
+ * through Zotero's Reader API. Falls back gracefully when no reader tab is
+ * open for the requested item.
+ *
+ * This provides:
+ * - Real PDF page numbers (not estimated via character count)
+ * - Hierarchical structure (multi-level TOC)
+ * - Accurate section names in any language (no heuristic matching)
+ * - Page position mapping (via PDF destination coordinates)
+ */
+
+import type { NativeOutlineItem } from "../../../types/tool";
+import { getErrorMessage } from "../../../utils/common";
+
+/**
+ * Try to extract native outline for a given item from the PDF.js viewer.
+ * Returns null if the item is not open in any reader tab, or the PDF has no outline.
+ */
+export async function extractNativeOutline(
+  itemKey: string,
+): Promise<NativeOutlineItem[] | null> {
+  try {
+    const reader = findReaderForItem(itemKey);
+    if (!reader) return null;
+
+    const iframeWindow = (reader as any)._iframeWindow;
+    if (!iframeWindow) return null;
+
+    // Zotero 9 的 PDF.js viewer 被 Xray 包裹，需要 wrappedJSObject 绕过
+    let pdfApp;
+    try { pdfApp = iframeWindow.PDFViewerApplication; } catch (_) {}
+    if (!pdfApp) {
+      try { pdfApp = iframeWindow.wrappedJSObject?.PDFViewerApplication; } catch (_) {}
+    }
+    if (!pdfApp) return null;
+
+    const pdfDocument = pdfApp.pdfDocument;
+    if (!pdfDocument || typeof pdfDocument.getOutline !== "function") return null;
+
+    const outline = await pdfDocument.getOutline();
+    if (!outline || outline.length === 0) return null;
+
+    return await convertOutlineItems(outline, pdfDocument, 0);
+  } catch (error) {
+    ztoolkit.log("[nativeOutlineExtractor] Error:", getErrorMessage(error));
+    return null;
+  }
+}
+
+/**
+ * Find a reader tab that has the given itemKey open.
+ * Checks the active tab first (fast path), then falls back to scanning all
+ * open reader tabs.
+ */
+function findReaderForItem(itemKey: string): any | null {
+  const mainWindow = Zotero.getMainWindow() as
+    | (Window & { Zotero_Tabs?: Record<string, any> })
+    | null;
+  if (!mainWindow?.Zotero_Tabs) return null;
+
+  const tabs = mainWindow.Zotero_Tabs;
+
+  // Fast path: check the currently active tab
+  const activeTabID = (tabs as any).selectedID;
+  if (activeTabID) {
+    const reader = Zotero.Reader?.getByTabID(activeTabID);
+    if (reader && readerItemMatches(reader, itemKey)) return reader;
+  }
+
+  // Fallback: scan all tabs to find a reader tab for this item.
+  // Zotero internally tracks readers; try its reader map if available.
+  const readerMap: Record<string, any> | undefined =
+    (Zotero.Reader as any)._readers;
+  if (readerMap) {
+    for (const reader of Object.values(readerMap)) {
+      if (readerItemMatches(reader, itemKey)) return reader;
+    }
+  }
+
+  return null;
+}
+
+function readerItemMatches(reader: any, itemKey: string): boolean {
+  if (!reader || typeof reader.itemID !== "number") return false;
+  const item = Zotero.Items.get(reader.itemID);
+  return item?.key === itemKey;
+}
+
+/**
+ * Recursively convert PDF.js outline items to our NativeOutlineItem format,
+ * resolving each destination to a real PDF page number.
+ */
+async function convertOutlineItems(
+  items: any[],
+  pdfDocument: any,
+  level: number,
+): Promise<NativeOutlineItem[]> {
+  const result: NativeOutlineItem[] = [];
+
+  for (const item of items) {
+    if (!item || !item.title) continue;
+
+    const pageNumber = item.dest
+      ? await resolveDestPage(item.dest, pdfDocument)
+      : 0;
+
+    const children = item.items
+      ? await convertOutlineItems(item.items, pdfDocument, level + 1)
+      : [];
+
+    result.push({ title: item.title, level, pageNumber, children });
+  }
+
+  return result;
+}
+
+/**
+ * Resolve a PDF.js destination to a 1-based page number.
+ *
+ * PDF.js destinations come in two forms:
+ * - explicit: [pageRef, x, y, zoom]  (most common)
+ * - named: string key looked up via pdfDocument.getDestination()
+ */
+async function resolveDestPage(
+  dest: any,
+  pdfDocument: any,
+): Promise<number> {
+  try {
+    // Explicit destination array: [pageRef, x, y, zoom]
+    if (Array.isArray(dest)) {
+      const pageRef = dest[0];
+      if (pageRef && typeof pageRef === "object" && "num" in pageRef) {
+        const pageIndex = await pdfDocument.getPageIndex(pageRef);
+        return pageIndex + 1;
+      }
+      // Some PDFs embed the (0-based) page index directly
+      if (typeof pageRef === "number") {
+        return pageRef + 1;
+      }
+      return 0;
+    }
+
+    // Named destination – look up the name, then recurse
+    if (typeof dest === "string") {
+      const resolved = await pdfDocument.getDestination(dest);
+      if (resolved && Array.isArray(resolved)) {
+        return resolveDestPage(resolved, pdfDocument);
+      }
+    }
+  } catch {
+    // Best-effort: page resolution failure is non-fatal
+  }
+
+  return 0;
+}

--- a/src/modules/chat/pdf-tools/toolExecutors.ts
+++ b/src/modules/chat/pdf-tools/toolExecutors.ts
@@ -4,6 +4,7 @@
 
 import type {
   PaperStructureExtended,
+  NativeOutlineItem,
   GetPaperSectionArgs,
   SearchPaperContentArgs,
   GetPagesArgs,
@@ -428,17 +429,48 @@ export function executeSearchWithRegex(
 
 /**
  * 执行 get_outline - 获取文档大纲
+ *
+ * 优先使用 PDF 原生大纲（如果有），提供真实页码和层级结构。
+ * 回退到基于文本的启发式章节检测。
  */
 export function executeGetOutline(
   paperStructure: PaperStructureExtended,
 ): string {
-  const { sections, pageCount } = paperStructure;
+  const { sections, pageCount, nativeOutline } = paperStructure;
 
+  // 优先使用 PDF 原生大纲
+  if (nativeOutline && nativeOutline.length > 0) {
+    const lines: string[] = [];
+    lines.push(`Document Outline (from PDF bookmarks, ${pageCount} pages total):\n`);
+
+    // 计算扁平化后的条目总数
+    let totalItems = 0;
+    const countItems = (items: NativeOutlineItem[]) => {
+      for (const item of items) {
+        totalItems++;
+        countItems(item.children);
+      }
+    };
+    countItems(nativeOutline);
+
+    lines.push(formatNativeOutlineItems(nativeOutline, ""));
+    lines.push(`\n(${totalItems} outline items, ${pageCount} pages)`);
+
+    if (!paperStructure.sections.some((s) => s.normalizedName !== "full_text")) {
+      lines.push(
+        "\nNote: No heuristic section breakdown available — the native PDF outline above was used.",
+      );
+    }
+
+    return lines.join("\n");
+  }
+
+  // 回退：启发式章节检测
   if (
     sections.length === 0 ||
     (sections.length === 1 && sections[0].normalizedName === "full_text")
   ) {
-    return `${HEURISTIC_SECTION_NOTE}\n\nNo structured outline detected. The paper may not have clear section headings.`;
+    return "No structured outline detected. The paper may not have clear section headings. Try opening the PDF in the Zotero reader for a more accurate outline from native PDF bookmarks.";
   }
 
   const outline = sections
@@ -453,17 +485,45 @@ export function executeGetOutline(
     })
     .join("\n");
 
-  return `${HEURISTIC_SECTION_NOTE}\n\nDocument Outline (${pageCount} pages total):\n\n${outline}`;
+  return `Document Outline (estimated from text, ${pageCount} pages total):\n\n${outline}`;
+}
+
+/**
+ * 递归格式化原生大纲条目为文本（带缩进层次）
+ */
+function formatNativeOutlineItems(
+  items: NativeOutlineItem[],
+  indent: string,
+): string {
+  return items
+    .map((item, index) => {
+      const pageStr = item.pageNumber > 0 ? `(Page ${item.pageNumber})` : "";
+      const line = `${indent}${index + 1}. ${item.title} ${pageStr}`.trim();
+      const childrenStr = item.children.length > 0
+        ? `\n${formatNativeOutlineItems(item.children, indent + "  ")}`
+        : "";
+      return `${line}${childrenStr}`;
+    })
+    .join("\n");
 }
 
 /**
  * 执行 list_sections - 列出所有章节
+ *
+ * 优先使用 PDF 原生大纲（如果有），提供层级和真实页码。
+ * 回退到启发式检测的章节列表。
  */
 export function executeListSections(
   paperStructure: PaperStructureExtended,
 ): string {
-  const { sections } = paperStructure;
+  const { sections, nativeOutline } = paperStructure;
 
+  // 优先使用 PDF 原生大纲
+  if (nativeOutline && nativeOutline.length > 0) {
+    return formatNativeSectionsList(nativeOutline);
+  }
+
+  // 回退到启发式检测
   if (sections.length === 0) {
     return `${HEURISTIC_SECTION_NOTE}\n\nNo sections detected.`;
   }
@@ -483,6 +543,27 @@ export function executeListSections(
     .join("\n\n");
 
   return `${HEURISTIC_SECTION_NOTE}\n\nAvailable sections (${sections.length} total):\n\n${formatted}`;
+}
+
+/**
+ * 格式化原生大纲为章节列表（递归处理层级）
+ */
+function formatNativeSectionsList(
+  items: NativeOutlineItem[],
+  indent: string = "",
+): string {
+  const lines: string[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const pageStr = item.pageNumber > 0 ? ` Page ${item.pageNumber}` : "";
+    const childCount = item.children.length;
+    const extra = childCount > 0 ? ` (${childCount} sub-items)` : "";
+    lines.push(`${indent}${i + 1}. ${item.title}${pageStr}${extra}`);
+    if (item.children.length > 0) {
+      lines.push(formatNativeSectionsList(item.children, indent + "  "));
+    }
+  }
+  return lines.join("\n");
 }
 
 /**

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -182,6 +182,14 @@ export interface PaperSection {
   endIndex: number;
 }
 
+// PDF 原生大纲条目（pdf.js getOutline 结果）
+export interface NativeOutlineItem {
+  title: string;
+  level: number; // 层级深度(0=顶层)
+  pageNumber: number; // PDF 真实页码（从 pdf.js 解析得到）
+  children: NativeOutlineItem[];
+}
+
 // 工具名称枚举
 export type PaperToolName =
   | "web_search"
@@ -279,10 +287,11 @@ export interface PageInfo {
   content: string;
 }
 
-// 扩展 PaperStructure 包含页面信息
+// 扩展 PaperStructure 包含页面信息和大纲
 export interface PaperStructureExtended extends PaperStructure {
   pages: PageInfo[];
   pageCount: number;
+  nativeOutline?: NativeOutlineItem[]; // PDF 原生大纲（如果可用）
 }
 
 // ========== 新增工具参数类型 ==========


### PR DESCRIPTION
添加了 NativeOutlineItem 类型以及 nativeOutlineExtractor，该提取器访问 Zotero 的 PDF 阅读器以调用 pdfDocument.getOutline()。当 PDF 阅读器打开时，提供具有准确页码的层次结构大纲，否则透明地回退到现有基于部分检测的启发式文本。-
- get_outline：带缩进层次结构 + 实际页码的原生大纲
- list_sections：原生大纲的层次结构部分列表
- extractAndParsePaper：在启发式解析后尝试原生大纲